### PR TITLE
process dead letter from mns

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -46,6 +46,7 @@ export interface Client {
       ReceiptHandle?: string
       MD5OfBody?: string
       Body?: string
+      DequeueCount?: string
     }[]
   }>
 
@@ -357,6 +358,7 @@ export class MnsClient implements Client {
         ReceiptHandle: message.ReceiptHandle,
         MD5OfBody: message.MessageBodyMD5,
         Body: message.MessageBody,
+        DequeueCount: message.DequeueCount,
       })),
     }
   }

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -62,9 +62,7 @@ class Consumer<T = any> extends EventEmitter {
                 this._pull()
               })
               .catch((err2: Error) => {
-                err2.message = `Consumer[${this.queue.name}] processingMessages error: ${
-                  err2.message
-                }`
+                err2.message = `Consumer[${this.queue.name}] processingMessages error: ${err2.message}`
                 this.emit('error', err2)
                 this._pull()
               })
@@ -101,6 +99,7 @@ class Consumer<T = any> extends EventEmitter {
       ? new Bluebird<void>((resolve, reject) => {
           this.handler(decodedMessages, err => {
             if (err) {
+              console.log('decodedMessages', decodedMessages)
               reject(err)
             } else {
               resolve(this._deleteMessageBatch(messages))

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -123,25 +123,25 @@ class Consumer<T = any> extends EventEmitter {
 
     return (this.batchHandle
       ? new Bluebird<void>((resolve, reject) => {
-        this.handler(decodedMessages, err => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(this._deleteMessageBatch(messages))
-          }
-        })
-      })
-      : Bluebird.map(decodedMessages, (decodedMessage, i) => {
-        return new Promise((resolve, reject) => {
-          this.handler(decodedMessage, err => {
+          this.handler(decodedMessages, err => {
             if (err) {
               reject(err)
             } else {
-              resolve(this._deleteMessage(messages[i]))
+              resolve(this._deleteMessageBatch(messages))
             }
           })
         })
-      })
+      : Bluebird.map(decodedMessages, (decodedMessage, i) => {
+          return new Promise((resolve, reject) => {
+            this.handler(decodedMessage, err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(this._deleteMessage(messages[i]))
+              }
+            })
+          })
+        })
     )
       .timeout(this.visibilityTimeout * 1000)
       .catch((err: Error) => {

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -119,25 +119,25 @@ class Consumer<T = any> extends EventEmitter {
 
     return (this.batchHandle
       ? new Bluebird<void>((resolve, reject) => {
-        this.handler(decodedMessages, err => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(this._deleteMessageBatch(messages))
-          }
-        })
-      })
-      : Bluebird.map(decodedMessages, (decodedMessage, i) => {
-        return new Promise((resolve, reject) => {
-          this.handler(decodedMessage, err => {
+          this.handler(decodedMessages, err => {
             if (err) {
               reject(err)
             } else {
-              resolve(this._deleteMessage(messages[i]))
+              resolve(this._deleteMessageBatch(messages))
             }
           })
         })
-      })
+      : Bluebird.map(decodedMessages, (decodedMessage, i) => {
+          return new Promise((resolve, reject) => {
+            this.handler(decodedMessage, err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(this._deleteMessage(messages[i]))
+              }
+            })
+          })
+        })
     )
       .timeout(this.visibilityTimeout * 1000)
       .catch((err: Error) => {

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -125,25 +125,25 @@ class Consumer<T = any> extends EventEmitter {
 
     return (this.batchHandle
       ? new Bluebird<void>((resolve, reject) => {
-        this.handler(decodedMessages, err => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(this._deleteMessageBatch(messages))
-          }
-        })
-      })
-      : Bluebird.map(decodedMessages, (decodedMessage, i) => {
-        return new Promise((resolve, reject) => {
-          this.handler(decodedMessage, err => {
+          this.handler(decodedMessages, err => {
             if (err) {
               reject(err)
             } else {
-              resolve(this._deleteMessage(messages[i]))
+              resolve(this._deleteMessageBatch(messages))
             }
           })
         })
-      })
+      : Bluebird.map(decodedMessages, (decodedMessage, i) => {
+          return new Promise((resolve, reject) => {
+            this.handler(decodedMessage, err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(this._deleteMessage(messages[i]))
+              }
+            })
+          })
+        })
     )
       .timeout(this.visibilityTimeout * 1000)
       .catch((err: Error) => {

--- a/lib/queue.ts
+++ b/lib/queue.ts
@@ -136,9 +136,7 @@ class Queue extends EventEmitter {
         this.deadLetterQueue = deadLetterQueue
 
         // set redrive policy on origin queue
-        createParams.Attributes!.RedrivePolicy = `{"maxReceiveCount":"${
-          opts.maxReceiveCount
-        }", "deadLetterTargetArn":"${this.config.sqsArnPrefix}${deadLetterQueue.realName}"}`
+        createParams.Attributes!.RedrivePolicy = `{"maxReceiveCount":"${opts.maxReceiveCount}", "deadLetterTargetArn":"${this.config.sqsArnPrefix}${deadLetterQueue.realName}"}`
 
         deadLetterQueue.on('ready', () => {
           resolve()

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -53,9 +53,7 @@ class Topic extends EventEmitter {
         })
         .then(data2 => {
           debug(
-            `Succeed subscribing ${queue.name}(${queue.realName}) to ${this.name}(${
-              this.realName
-            })`,
+            `Succeed subscribing ${queue.name}(${queue.realName}) to ${this.name}(${this.realName})`,
           )
           resolve(data2)
         })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "3.2.0-alpha",
+  "version": "3.2.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -256,6 +256,12 @@
       "version": "3.5.20",
       "resolved": "https://registry.npm.taobao.org/@types/bluebird/download/@types/bluebird-3.5.20.tgz",
       "integrity": "sha1-9jYxcq3W9Oq7jK2lPKmvJ4Ho1qE="
+    },
+    "@types/lodash": {
+      "version": "4.14.146",
+      "resolved": "https://registry.npm.taobao.org/@types/lodash/download/@types/lodash-4.14.146.tgz?cache=0&sync_timestamp=1573233149765&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Flodash%2Fdownload%2F%40types%2Flodash-4.14.146.tgz",
+      "integrity": "sha1-3g0shhABLxKmp5ZFUFTLxlT4/s8=",
+      "dev": true
     },
     "@types/node": {
       "version": "8.5.1",
@@ -3361,8 +3367,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npm.taobao.org/lodash/download/lodash-4.17.15.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flodash%2Fdownload%2Flodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
-      "dev": true
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "3.2.0-alpha.4",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "3.1.0",
+  "version": "3.2.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4246,6 +4246,12 @@
       "version": "0.2.0",
       "resolved": "http://registry.npm.taobao.org/preserve/download/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npm.taobao.org/prettier/download/prettier-1.18.2.tgz",
+      "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
       "dev": true
     },
     "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "3.2.0-alpha",
+  "version": "3.2.0-alpha.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,6 +17,7 @@
     "@types/bluebird": "3.5.20",
     "@types/node": "8.5.1",
     "bluebird": "3.5.1",
+    "lodash": "4.17.15",
     "debug": "3.1.0"
   },
   "peerDependencies": {
@@ -24,10 +25,11 @@
     "@ruguoapp/mns-node-sdk": "1.1.0"
   },
   "devDependencies": {
+    "@ruguoapp/mns-node-sdk": "1.1.0",
+    "@types/lodash": "4.14.146",
     "@types/sinon": "4.3.3",
     "ava": "^0.25.0",
     "aws-sdk": "2.244.1",
-    "@ruguoapp/mns-node-sdk": "1.1.0",
     "sinon": "5.0.7",
     "source-map-support": "0.5.6",
     "tslint": "^5.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "3.1.0",
+  "version": "3.2.0-alpha",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,6 +33,7 @@
     "tslint": "^5.18.0",
     "tslint-config-prettier": "1.13.0",
     "tslint-jike-node": "0.0.14",
+    "prettier": "^1.18.2",
     "typescript": "2.8.3"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "3.2.0-alpha.4",
+  "version": "3.2.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
根据mns receiveMessage的DequeueCount属性获取每条消息被重复消费的次数，在本地尝试进行dead letter的处理。

附：现在阿里云共有227个dead letter队列，维护这些队列每天需要100元左右的成本。